### PR TITLE
Various improvements

### DIFF
--- a/pretalx_downstream/forms.py
+++ b/pretalx_downstream/forms.py
@@ -22,7 +22,7 @@ class UpstreamSettingsForm(HierarkeyForm):
         widget=RadioSelect,
     )
     downstream_discard_after = CharField(
-        label=_("Discard everything after"),
+        label=_("Discard version name after"),
         help_text=_(
             "Everything after the first occurence of the entered string "
             "in schedule version will be discarded. Leave empty if you "

--- a/pretalx_downstream/forms.py
+++ b/pretalx_downstream/forms.py
@@ -1,13 +1,34 @@
-from django import forms
+from django.forms import CharField, ChoiceField, IntegerField, RadioSelect, URLField
 from django.utils.translation import gettext_lazy as _
 from hierarkey.forms import HierarkeyForm
 
 
 class UpstreamSettingsForm(HierarkeyForm):
 
-    downstream_upstream_url = forms.URLField(label=_("Upstream URL"))
-    downstream_interval = forms.IntegerField(
+    downstream_upstream_url = URLField(
+        label=_("Upstream URL"),
+        help_text=_("URL of your schedule.xml"),
+        required=True,
+    )
+    downstream_interval = IntegerField(
         min_value=5, label=_("Interval"), help_text=_("Checking interval in minutes.")
+    )
+    downstream_checking_time = ChoiceField(
+        choices=(
+            ("event", _("Check only during event time")),
+            ("always", _("From now until one day after the event ends")),
+        ),
+        label=_("Schedule check time"),
+        widget=RadioSelect,
+    )
+    downstream_discard_after = CharField(
+        label=_("Discard everything after"),
+        help_text=_(
+            "Everything after the first occurence of the entered string "
+            "in schedule version will be discarded. Leave empty if you "
+            "want to keep the full schedule version"
+        ),
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):

--- a/pretalx_downstream/signals.py
+++ b/pretalx_downstream/signals.py
@@ -19,8 +19,7 @@ def refresh_upstream_schedule(sender, request=None, **kwargs):
         with scope(event=event):
             if (
                 event.settings.downstream_upstream_url
-                and event.datetime_from
-                < _now
+                and _now
                 < (event.datetime_to + dt.timedelta(days=1))
             ):
                 interval = event.settings.downstream_interval or 15

--- a/pretalx_downstream/signals.py
+++ b/pretalx_downstream/signals.py
@@ -5,11 +5,15 @@ from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django_scopes import scope
+from pretalx.common.models.settings import hierarkey
 from pretalx.common.signals import periodic_task
 from pretalx.event.models import Event
 from pretalx.orga.signals import nav_event_settings
 
 from .tasks import task_refresh_upstream_schedule
+
+hierarkey.add_default("downstream_interval", 15)
+hierarkey.add_default("downstream_checking_time", "event")
 
 
 @receiver(periodic_task)
@@ -17,25 +21,35 @@ def refresh_upstream_schedule(sender, request=None, **kwargs):
     _now = now()
     for event in Event.objects.all():
         with scope(event=event):
-            if event.settings.downstream_upstream_url and _now < (
-                event.datetime_to + dt.timedelta(days=1)
+            if not event.settings.downstream_upstream_url:
+                continue
+
+            if not _now < (event.datetime_to + dt.timedelta(days=1)):
+                continue
+
+            if not (
+                event.settings.downstream_checking_time == "always"
+                or event.datetime_from < _now
             ):
-                interval = event.settings.downstream_interval or 15
-                try:
-                    interval = int(interval)
-                except TypeError:
-                    interval = 5
-                interval = dt.timedelta(minutes=interval)
-                last_pulled = event.settings.upstream_last_sync
-                if (
-                    not last_pulled
-                    or _now
-                    - dt.datetime.strptime(last_pulled, "%Y-%m-%dT%H:%M:%S.%f%z")
-                    > interval
-                ):
-                    task_refresh_upstream_schedule.apply_async(
-                        kwargs={"event_slug": event.slug}
-                    )
+                continue
+
+            try:
+                interval = int(event.settings.downstream_interval)
+            except TypeError:
+                interval = 5
+
+            interval = dt.timedelta(minutes=interval)
+            last_pulled = event.settings.upstream_last_sync
+
+            if (
+                not last_pulled
+                or _now - dt.datetime.strptime(last_pulled, "%Y-%m-%dT%H:%M:%S.%f%z")
+                > interval
+            ):
+                task_refresh_upstream_schedule.apply_async(
+                    kwargs={"event_slug": event.slug}
+                )
+
             if event.upstream_results.count() > 3:
                 latest_three = list(event.upstream_results.order_by("-timestamp")[:3])
                 event.upstream_results.filter(

--- a/pretalx_downstream/signals.py
+++ b/pretalx_downstream/signals.py
@@ -17,10 +17,8 @@ def refresh_upstream_schedule(sender, request=None, **kwargs):
     _now = now()
     for event in Event.objects.all():
         with scope(event=event):
-            if (
-                event.settings.downstream_upstream_url
-                and _now
-                < (event.datetime_to + dt.timedelta(days=1))
+            if event.settings.downstream_upstream_url and _now < (
+                event.datetime_to + dt.timedelta(days=1)
             ):
                 interval = event.settings.downstream_interval or 15
                 try:
@@ -29,7 +27,12 @@ def refresh_upstream_schedule(sender, request=None, **kwargs):
                     interval = 5
                 interval = dt.timedelta(minutes=interval)
                 last_pulled = event.settings.upstream_last_sync
-                if not last_pulled or _now - dt.datetime.strptime(last_pulled, '%Y-%m-%dT%H:%M:%S.%f%z') > interval:
+                if (
+                    not last_pulled
+                    or _now
+                    - dt.datetime.strptime(last_pulled, "%Y-%m-%dT%H:%M:%S.%f%z")
+                    > interval
+                ):
                     task_refresh_upstream_schedule.apply_async(
                         kwargs={"event_slug": event.slug}
                     )

--- a/pretalx_downstream/signals.py
+++ b/pretalx_downstream/signals.py
@@ -28,8 +28,8 @@ def refresh_upstream_schedule(sender, request=None, **kwargs):
                 except TypeError:
                     interval = 5
                 interval = dt.timedelta(minutes=interval)
-                last_pulled = event.settings.downstream_last_sync
-                if not last_pulled or _now - last_pulled > interval:
+                last_pulled = event.settings.upstream_last_sync
+                if not last_pulled or _now - dt.datetime.strptime(last_pulled, '%Y-%m-%dT%H:%M:%S.%f%z') > interval:
                     task_refresh_upstream_schedule.apply_async(
                         kwargs={"event_slug": event.slug}
                     )

--- a/pretalx_downstream/tasks.py
+++ b/pretalx_downstream/tasks.py
@@ -19,7 +19,7 @@ from pretalx.submission.models import Submission, SubmissionType, Track
 
 from .models import UpstreamResult
 
-logger = getLogger('pretalx_downstream')
+logger = getLogger("pretalx_downstream")
 
 
 @app.task()
@@ -27,7 +27,7 @@ def task_refresh_upstream_schedule(event_slug):
     with scopes_disabled():
         event = Event.objects.get(slug__iexact=event_slug)
     with scope(event=event):
-        logger.info(f'processing {event.slug}')
+        logger.info(f"processing {event.slug}")
         url = event.settings.downstream_upstream_url
         if not url:
             raise Exception(
@@ -49,8 +49,8 @@ def task_refresh_upstream_schedule(event_slug):
         m = hashlib.sha256()
         m.update(response.content)
         if last_result:
-            logger.debug(f'last known checksum: {last_result.checksum}')
-            logger.debug(f'checksum now: {m}')
+            logger.debug(f"last known checksum: {last_result.checksum}")
+            logger.debug(f"checksum now: {m}")
 
             if m == last_result.checksum:
                 event.settings.upstream_last_sync = now()
@@ -62,7 +62,7 @@ def task_refresh_upstream_schedule(event_slug):
             not event.current_schedule
             or schedule_version != event.current_schedule.version
         )
-        logger.debug(f'release_new_version={release_new_version}')
+        logger.debug(f"release_new_version={release_new_version}")
         changes, schedule = process_frab(
             root, event, release_new_version=release_new_version
         )
@@ -70,7 +70,7 @@ def task_refresh_upstream_schedule(event_slug):
             event=event, schedule=schedule, changes=json.dumps(changes), content=content
         )
         event.settings.upstream_last_sync = now()
-        logger.info(f'refreshed schedule of {event.slug}')
+        logger.info(f"refreshed schedule of {event.slug}")
 
 
 @transaction.atomic()

--- a/pretalx_downstream/tasks.py
+++ b/pretalx_downstream/tasks.py
@@ -49,7 +49,7 @@ def task_refresh_upstream_schedule(event_slug):
             return
 
         root = ET.fromstring(content)
-        schedule_version = root.find("version").text
+        schedule_version = root.find("version").text.split(";")[0]
         release_new_version = (
             not event.current_schedule
             or schedule_version != event.current_schedule.version
@@ -79,7 +79,7 @@ def process_frab(root, event, release_new_version):
 
     schedule = None
     if release_new_version:
-        schedule_version = root.find("version").text
+        schedule_version = root.find("version").text.split(";")[0]
         try:
             event.wip_schedule.freeze(schedule_version, notify_speakers=False)
             schedule = event.schedules.get(version=schedule_version)

--- a/pretalx_downstream/tasks.py
+++ b/pretalx_downstream/tasks.py
@@ -183,12 +183,13 @@ def _create_talk(*, talk, room, event):
         )
         track = [t for t in tracks if str(t.name) == talk.find("track").text]
 
-    if track:
-        track = track[0]
-    else:
-        track = Track.objects.create(
-            name=talk.find("track").text or "default", event=event
-        )
+        if track:
+            track = track[0]
+        else:
+            track = Track.objects.create(
+                name=talk.find("track").text, event=event
+            )
+
 
     optout = False
     with suppress(AttributeError):
@@ -212,7 +213,8 @@ def _create_talk(*, talk, room, event):
         event=event, code=code, defaults={"submission_type": sub_type}
     )
     sub.submission_type = sub_type
-    sub.track = track
+    if track:
+        sub.track = track
 
     changes = _get_changes(talk, optout, sub)
     sub.save()

--- a/pretalx_downstream/tasks.py
+++ b/pretalx_downstream/tasks.py
@@ -69,6 +69,7 @@ def task_refresh_upstream_schedule(event_slug):
         UpstreamResult.objects.create(
             event=event, schedule=schedule, changes=json.dumps(changes), content=content
         )
+        event.settings.upstream_last_sync = now()
         logger.info(f'refreshed schedule of {event.slug}')
 
 

--- a/pretalx_downstream/templates/pretalx_downstream/settings.html
+++ b/pretalx_downstream/templates/pretalx_downstream/settings.html
@@ -8,6 +8,12 @@
     <form method="post">
         {% csrf_token %}
         {% bootstrap_form form layout='event' %}
+{% if request.event.settings.upstream_last_sync %}
+        <p>
+            <!-- FIXME format this correctly -->
+            Last automatic sync: {{ request.event.settings.upstream_last_sync }}
+        </p>
+{% endif %}
         <div class="submit-group panel">
             <span></span>
             <span class="d-flex flex-row-reverse">

--- a/pretalx_downstream/templates/pretalx_downstream/settings.html
+++ b/pretalx_downstream/templates/pretalx_downstream/settings.html
@@ -1,6 +1,7 @@
 {% extends "orga/base.html" %}
 {% load bootstrap4 %}
 {% load i18n %}
+{% load tz %}
 
 {% block content %}
 
@@ -8,10 +9,9 @@
     <form method="post">
         {% csrf_token %}
         {% bootstrap_form form layout='event' %}
-{% if request.event.settings.upstream_last_sync %}
+{% if last_pulled %}
         <p>
-            <!-- FIXME format this correctly -->
-            Last automatic sync: {{ request.event.settings.upstream_last_sync }}
+            Last automatic sync: {{ last_pulled|date:"Y-m-d H:i:s e" }}
         </p>
 {% endif %}
         <div class="submit-group panel">

--- a/pretalx_downstream/views.py
+++ b/pretalx_downstream/views.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
@@ -37,4 +39,19 @@ class UpstreamSettings(PermissionRequired, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        return {"obj": self.request.event, "attribute_name": "settings", **kwargs}
+        return {
+            "obj": self.request.event,
+            "attribute_name": "settings",
+            **kwargs,
+        }
+
+    def get_context_data(self, **kwargs):
+        kwargs = super().get_context_data(**kwargs)
+        last_pulled = self.request.event.settings.upstream_last_sync
+        if last_pulled:
+            last_pulled = dt.datetime.strptime(last_pulled, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return {
+            "last_pulled": last_pulled,
+            **kwargs,
+        }
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,22 @@
 [isort]
-balanced_wrapping = True
-combine_as_imports = True
-default_section = THIRDPARTY
-include_trailing_comma = True
-known_third_party = pretalx
-line_length = 80
-multi_line_output = 5
-not_skip = __init__.py
+multi_line_output = 3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
 skip = migrations,setup.py
+default_section = THIRDPARTY
+known_third_party = pretalx
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE=pretalx.common.settings.test_settings
+
+[check-manifest]
+ignore =
+  LICENSE
+  README.rst
+  tests
+  tests/*
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
- Logging
- Show when update job ran last
- Fix "does this event need refreshing" check
- Discard everything in schedule version after first $character (configurable)
- Always import schedule, not just after event start (configurable)
- Bump setup.cfg to current cookiecutter template
- Fixed creation of lots of "default" tracks when importing schedule without tracks

It would be nice if we could format the "last sync" date in a more user-friendly way, but it seems the timestamp field gets converted to a string when storing in `event.settings`, so there's no way of formatting that (easily), i think.