### PR TITLE
Handle person.text being NoneType properly

### DIFF
--- a/pretalx_downstream/tasks.py
+++ b/pretalx_downstream/tasks.py
@@ -227,7 +227,7 @@ def _create_talk(*, talk, room, event):
     persons = talk.find("persons")
     if persons:
         for person in persons.findall("person"):
-            if person.text.strip():
+            if person.text and person.text.strip():
                 user = _create_user(person.text.strip(), event)
                 sub.speakers.add(user)
 


### PR DESCRIPTION
Fixes this:
```
Mar 18 16:21:06 pretalx celery[11855]: [2022-03-18 15:21:06,071: INFO/MainProcess] Received task: pretalx_downstream.tasks.task_refresh_upstream_schedule[e1811270-ffd1-4c71-bbd6-3a0742a9a65b]
Mar 18 16:21:06 pretalx celery[11855]: [2022-03-18 15:21:06,078: INFO/ForkPoolWorker-1] processing rc3-2020
Mar 18 16:21:07 pretalx celery[11855]: [2022-03-18 15:21:07,557: ERROR/ForkPoolWorker-1] Task pretalx_downstream.tasks.task_refresh_upstream_schedule[e1811270-ffd1-4c71-bbd6-3a0742a9a65b] raised unexpected: AttributeError("'NoneType' object has no attribute 'strip'")
Mar 18 16:21:07 pretalx celery[11855]: Traceback (most recent call last):
Mar 18 16:21:07 pretalx celery[11855]:   File "/opt/pretalx/venv/lib/python3.7/site-packages/celery/app/trace.py", line 412, in trace_task
Mar 18 16:21:07 pretalx celery[11855]:     R = retval = fun(*args, **kwargs)
Mar 18 16:21:07 pretalx celery[11855]:   File "/opt/pretalx/venv/lib/python3.7/site-packages/celery/app/trace.py", line 704, in __protected_call__
Mar 18 16:21:07 pretalx celery[11855]:     return self.run(*args, **kwargs)
Mar 18 16:21:07 pretalx celery[11855]:   File "/opt/pretalx/plugin_downstream/pretalx_downstream/tasks.py", line 78, in task_refresh_upstream_schedule
Mar 18 16:21:07 pretalx celery[11855]:     root, event, release_new_version=release_new_version
Mar 18 16:21:07 pretalx celery[11855]:   File "/usr/lib/python3.7/contextlib.py", line 74, in inner
Mar 18 16:21:07 pretalx celery[11855]:     return func(*args, **kwds)
Mar 18 16:21:07 pretalx celery[11855]:   File "/opt/pretalx/plugin_downstream/pretalx_downstream/tasks.py", line 100, in process_frab
Mar 18 16:21:07 pretalx celery[11855]:     changes.update(_create_talk(talk=talk, room=room, event=event))
Mar 18 16:21:07 pretalx celery[11855]:   File "/opt/pretalx/plugin_downstream/pretalx_downstream/tasks.py", line 230, in _create_talk
Mar 18 16:21:07 pretalx celery[11855]:     if person.text.strip():
Mar 18 16:21:07 pretalx celery[11855]: AttributeError: 'NoneType' object has no attribute 'strip'
```